### PR TITLE
refactor: Replace 'PRC' timezone with 'Asia/Shanghai' for Debian 13+ compatibility

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -1145,7 +1145,7 @@ class Calendar
      *
      * @return \DateTime
      */
-    protected function makeDate($string = 'now', $timezone = 'PRC')
+    protected function makeDate($string = 'now', $timezone = 'Asia/Shanghai')
     {
         return new DateTime($string, new DateTimeZone($timezone));
     }


### PR DESCRIPTION
## Summary

Replace the deprecated 'PRC' timezone identifier with the IANA standard 'Asia/Shanghai' timezone identifier to ensure compatibility with Debian 13 and future Linux distributions.

## Changes

- Updated the default `$timezone` parameter in `makeDate()` method from `'PRC'` to `'Asia/Shanghai'`

## Motivation

Starting with Debian 13, the 'PRC' timezone identifier has been removed from the default timezone database (`tzdata` package). To continue using the 'PRC' timezone on Debian 13+, users would need to install an additional package:

```bash
sudo apt install tzdata-legacy
```

This creates an unnecessary dependency and potential compatibility issues for users running the library on modern Debian-based systems.

## Technical Details
- Both 'PRC' and 'Asia/Shanghai' represent the same timezone (UTC+8, China Standard Time)
- 'Asia/Shanghai' is the IANA (Internet Assigned Numbers Authority) standard timezone identifier
- This change maintains backward compatibility as the timezone behavior remains identical
- 'Asia/Shanghai' is more widely supported across different platforms and will continue to be maintained in the standard tzdata package

## Benefits
- ✅ Works out-of-the-box on Debian 13+ without requiring additional packages
- ✅ Better long-term maintainability using standardized timezone identifiers
- ✅ No breaking changes - functionality remains the same
- ✅ Improved cross-platform compatibility

## Testing
The change has been tested and confirmed to work correctly with the existing test suite. Both timezone identifiers represent the same UTC offset and DST rules.